### PR TITLE
fix: request explicit pnpm scope if flag is active

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,11 @@ Run the tool using the following command structure:
 ```
 usage: main.py [-h] -p PROJECT_REPO_NAME -v RELEASE_VERSION_OLD
                [-vn RELEASE_VERSION_NEW] -s [-d] [-n] -pm
-               {yarn-classic,yarn-berry,pnpm,npm,maven} [--pnpm-scope]
-               [--debug] [--no-gradual-report] [--check-source-code]
-               [--check-release-tags] [--check-deprecated] [--check-forks]
-               [--check-provenance] [--check-code-signature]
+               {yarn-classic,yarn-berry,pnpm,npm,maven}
+               [--pnpm-scope PNPM_SCOPE] [--debug] [--no-gradual-report]
+               [--check-source-code] [--check-release-tags]
+               [--check-deprecated] [--check-forks] [--check-provenance]
+               [--check-code-signature]
 
 options:
   -h, --help            show this help message and exit
@@ -82,7 +83,8 @@ options:
                         search.
   -pm {yarn-classic,yarn-berry,pnpm,npm,maven}, --package-manager {yarn-classic,yarn-berry,pnpm,npm,maven}
                         The package manager used in the project.
-  --pnpm-scope          Extract dependencies from pnpm with a specific scope
+  --pnpm-scope PNPM_SCOPE
+                        Extract dependencies from pnpm with a specific scope
                         using 'pnpm list --filter <scope> --depth Infinity'
                         command. Configure the scope in tool_config.py file.
   --debug               Enable debug mode.

--- a/tool/extract_deps.py
+++ b/tool/extract_deps.py
@@ -193,7 +193,7 @@ def extract_deps_from_v1_yarn(yarn_lock_file):
         return {"resolutions": [], "patches": []}
 
 
-def get_pnpm_dep_tree(folder_path, version_tag, project_repo_name):
+def get_pnpm_dep_tree(folder_path, version_tag, project_repo_name, pnpm_scope):
     """
     Get pnpm dependency tree for the given project.
 
@@ -201,6 +201,7 @@ def get_pnpm_dep_tree(folder_path, version_tag, project_repo_name):
         folder_path (str): Path to the project folder
         version_tag (str): Version tag of the project
         project_repo_name (str): Name of the project repository
+        pnpm_scope (str): Scope of the pnpm package
 
     Returns:
         dict: Dependency tree
@@ -243,9 +244,9 @@ def get_pnpm_dep_tree(folder_path, version_tag, project_repo_name):
         if dir_if != dir_name:
             os.chdir(dir_name)
 
-        logging.info("Getting pnpm dependency tree by running %s", PNPM_LIST_COMMAND)
+        logging.info("Getting pnpm dependency tree by running %s", PNPM_LIST_COMMAND(pnpm_scope))
 
-        command = PNPM_LIST_COMMAND
+        command = PNPM_LIST_COMMAND(pnpm_scope)
         logging.info("Getting pnpm dependency tree...")
         result = subprocess.run(
             command,
@@ -281,13 +282,15 @@ def get_pnpm_dep_tree(folder_path, version_tag, project_repo_name):
             logging.info("Removed %s", dir_name)
 
 
-def extract_deps_from_pnpm_mono(folder_path, version_tag, project_repo_name):
+def extract_deps_from_pnpm_mono(folder_path, version_tag, project_repo_name, pnpm_scope):
     """
     Extract dependencies from a pnpm monorepo.
 
     Args:
         folder_path (str): Path to the monorepo folder
         version_tag (str): Version tag to use
+        project_repo_name (str): Name of the project repository
+        pnpm_scope (str): Scope of the pnpm package
 
     Returns:
         tuple: Lists of all dependencies and registry dependencies
@@ -297,7 +300,7 @@ def extract_deps_from_pnpm_mono(folder_path, version_tag, project_repo_name):
     workspace_dep = []
     patched_dep = []
 
-    tree, folder_path_for_this = get_pnpm_dep_tree(folder_path, version_tag, project_repo_name)
+    tree, folder_path_for_this = get_pnpm_dep_tree(folder_path, version_tag, project_repo_name, pnpm_scope)
 
     os.chdir("..")
     if tree is None:
@@ -308,7 +311,6 @@ def extract_deps_from_pnpm_mono(folder_path, version_tag, project_repo_name):
     logging.info("Extracting dependencies from pnpm list output")
 
     for line in tree:
-        # TODO: what's this?
         if "ledger-live-desktop" in line or "production dependency, optional only, dev only" in line:
             logging.info("ledger-live-desktop found")
             continue

--- a/tool/main.py
+++ b/tool/main.py
@@ -215,7 +215,9 @@ def get_deps(folder_path, project_repo_name, release_version, package_manager):
     if package_manager == "pnpm":
         if get_args().pnpm_scope:
             pnpm_scope = get_args().pnpm_scope
-            deps_list_all = extract_deps.extract_deps_from_pnpm_mono(folder_path, release_version, project_repo_name, pnpm_scope)
+            deps_list_all = extract_deps.extract_deps_from_pnpm_mono(
+                folder_path, release_version, project_repo_name, pnpm_scope
+            )
         else:
             yaml_lockfile, _, _ = get_lockfile(project_repo_name, release_version, package_manager)
             deps_list_all = extract_deps.extract_deps_from_pnpm_lockfile(yaml_lockfile)

--- a/tool/main.py
+++ b/tool/main.py
@@ -87,7 +87,7 @@ def get_args():
     )
     parser.add_argument(
         "--pnpm-scope",
-        action="store_true",
+        required=False,
         help="Extract dependencies from pnpm with a specific scope using 'pnpm list --filter <scope> --depth Infinity' command. Configure the scope in tool_config.py file.",
     )
     parser.add_argument(
@@ -214,7 +214,8 @@ def get_deps(folder_path, project_repo_name, release_version, package_manager):
     # if it is a pnpm monorepo
     if package_manager == "pnpm":
         if get_args().pnpm_scope:
-            deps_list_all = extract_deps.extract_deps_from_pnpm_mono(folder_path, release_version, project_repo_name)
+            pnpm_scope = get_args().pnpm_scope
+            deps_list_all = extract_deps.extract_deps_from_pnpm_mono(folder_path, release_version, project_repo_name, pnpm_scope)
         else:
             yaml_lockfile, _, _ = get_lockfile(project_repo_name, release_version, package_manager)
             deps_list_all = extract_deps.extract_deps_from_pnpm_lockfile(yaml_lockfile)

--- a/tool/tool_config.py
+++ b/tool/tool_config.py
@@ -17,11 +17,11 @@ import time
 from git import Repo
 
 # change this to the install command for your project
-PNPM_LIST_COMMAND = [
+PNPM_LIST_COMMAND = lambda scope: [
     "pnpm",
     "list",
     "--filter",
-    "ledger-live-desktop",
+    scope,
     "--depth",
     "Infinity",
 ]


### PR DESCRIPTION
Fixes the issue of it only being enabled for ledger-live-desktop, now users can activate it for whatever scope they want