### PR TITLE
fix: cached parent clash issue

### DIFF
--- a/tool/github_repo.py
+++ b/tool/github_repo.py
@@ -224,9 +224,7 @@ def process_package(
         valid_repo_info = "GitHub repository" == retrieved_info["message"]
         if parent != retrieved_info.get("parent", None):
             # tackles scenarios where parent was cached and then removed; incoming parent should take precedence
-            retrieved_info.update({
-                "parent": parent
-            })
+            retrieved_info.update({"parent": parent})
             cache_manager.github_cache.cache_github_url(package, retrieved_info)
         repos_output_json[package] = retrieved_info
         if valid_repo_info:

--- a/tool/github_repo.py
+++ b/tool/github_repo.py
@@ -220,14 +220,14 @@ def process_package(
 
         cache_manager.github_cache.cache_github_url(package, retrieved_info)
     else:
-        logging.info(f"Found cached URL for {package}: {retrieved_info['url']}")
+        logging.info(f"Found cached URL for {package}: {retrieved_info.get('url', '-')}")
         valid_repo_info = "GitHub repository" == retrieved_info["message"]
-        retrieved_info.update(
-            {
-                # avoids scenarios where parent was cached and then removed; incoming parent should take precedence
+        if parent != retrieved_info.get("parent", None):
+            # tackles scenarios where parent was cached and then removed; incoming parent should take precedence
+            retrieved_info.update({
                 "parent": parent
-            }
-        )
+            })
+            cache_manager.github_cache.cache_github_url(package, retrieved_info)
         repos_output_json[package] = retrieved_info
         if valid_repo_info:
             repos_output.append(retrieved_info["url"])

--- a/tool/github_repo.py
+++ b/tool/github_repo.py
@@ -222,10 +222,12 @@ def process_package(
     else:
         logging.info(f"Found cached URL for {package}: {retrieved_info['url']}")
         valid_repo_info = "GitHub repository" == retrieved_info["message"]
-        retrieved_info.update({
-            # avoids scenarios where parent was cached and then removed; incoming parent should take precedence
-            "parent": parent
-        })
+        retrieved_info.update(
+            {
+                # avoids scenarios where parent was cached and then removed; incoming parent should take precedence
+                "parent": parent
+            }
+        )
         repos_output_json[package] = retrieved_info
         if valid_repo_info:
             repos_output.append(retrieved_info["url"])

--- a/tool/github_repo.py
+++ b/tool/github_repo.py
@@ -222,6 +222,10 @@ def process_package(
     else:
         logging.info(f"Found cached URL for {package}: {retrieved_info['url']}")
         valid_repo_info = "GitHub repository" == retrieved_info["message"]
+        retrieved_info.update({
+            # avoids scenarios where parent was cached and then removed; incoming parent should take precedence
+            "parent": parent
+        })
         repos_output_json[package] = retrieved_info
         if valid_repo_info:
             repos_output.append(retrieved_info["url"])


### PR DESCRIPTION
cc @LogFlames 

I think this was the issue; essentially, parent information must be stored in two cache modules (github_repo's and extract_deps's). As such, even if the parent was re-calculated in extract_deps, without this snippet, the cached version would take precedence.