### PR TITLE
docs: Add link to check option descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ At the moment, we have configuration support to ignore smells for specific depen
 The dependencies can be set either as an exact match or as a regex pattern.
 You can either set "all" to ignore every check for the dependency or specify the checks you want to ignore.
 
-The possible specific [check options](https://github.com/chains-project/dirty-waters?tab=readme-ov-file#smell-check-options) are as follows:
+The possible specific [check options](https://github.com/chains-project/dirty-waters#smell-check-options) are as follows:
 
 - `"source_code"`
 - `"source_code_sha"`

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ At the moment, we have configuration support to ignore smells for specific depen
 The dependencies can be set either as an exact match or as a regex pattern.
 You can either set "all" to ignore every check for the dependency or specify the checks you want to ignore.
 
-The possible specific check options are as follows:
+The possible specific [check options](https://github.com/chains-project/dirty-waters?tab=readme-ov-file#smell-check-options) are as follows:
 
 - `"source_code"`
 - `"source_code_sha"`


### PR DESCRIPTION
Follow-up on #135 .

I found the options were described further down in the README but didn't find it at first (although now it is quite obvious). I propose to add a link to where it is described what each check does.