### PR TITLE
Suggest zizmor for GHA in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ open an issue and/or a pull request!
 - Missing dependencies: simply run mvn/pip/... install :)
 - Bloated dependencies: we recommend [DepClean](https://github.com/ASSERT-KTH/depclean) for Java, [depcheck](https://github.com/depcheck/depcheck) for NPM
 - Version constraint inconsistencies: we recommend [pipdeptree](https://github.com/tox-dev/pipdeptree) for Python
+- Smells in GitHub Actions: we recommend [zizmor](https://github.com/woodruffw/zizmor)
 
 ## License
 


### PR DESCRIPTION
Suggestion to add [zizmor](https://github.com/woodruffw/zizmor) as a tool for detecting smells in GitHub Actions to the "Other issues not handled by dirty-waters" section in the `README.md`.