### PR TITLE
feat: granular check-related information in reports

### DIFF
--- a/tool/main.py
+++ b/tool/main.py
@@ -520,7 +520,7 @@ def generate_static_report(analysis_results, project_info, is_old_version):
         project_info["enabled_checks"],
         project_info["gradual_report"],
         summary_filename=summary_file,
-        config=project_info["config"]
+        config=project_info["config"],
     )
 
 

--- a/tool/report_static.py
+++ b/tool/report_static.py
@@ -485,7 +485,8 @@ Gradual reports are enabled by default. You can disable this feature, and get a 
         preamble += "\n"
         md_file.write(preamble)
 
-        md_file.write("""
+        md_file.write(
+            """
 ## 📚 Table of Contents
 
 - [Enabled Checks](#enabled-checks)
@@ -495,7 +496,8 @@ Gradual reports are enabled by default. You can disable this feature, and get a 
 - [Call to Action](#call-to-action)
 - [Notes](#notes)
 - [Glossary](#glossary)
-""")
+"""
+        )
 
         # Section showing which checks were performed
         any_specific = any(enabled_checks.values())
@@ -554,7 +556,7 @@ Gradual reports are enabled by default. You can disable this feature, and get a 
                 md_file.write("\n</details>\n\n")
 
             md_file.write("---\n\n")
-        
+
         md_file.write("## Summary of Findings\n\n")
 
         md_file.write(
@@ -723,7 +725,8 @@ Gradual reports are enabled by default. You can disable this feature, and get a 
                 md_file.write("\n</details>\n\n\n")
 
         md_file.write("\n## Glossary\n\n")
-        md_file.write("""
+        md_file.write(
+            """
 - `source_code`: Whether a repo URL is present and valid
     - `source_code_sha`: Whether a commit SHA is available and valid
     - `forks`: Whether the repo is a fork
@@ -731,8 +734,8 @@ Gradual reports are enabled by default. You can disable this feature, and get a 
 - `provenance`: Whether build provenance/attestation is provided
 - `code_signature`: Whether a code signature is present and valid
 - `aliased_packages`: Whether a package is aliased under a different name
-""")
-
+"""
+        )
 
         md_file.write("---\n")
         md_file.write("\nReport created by [dirty-waters](https://github.com/chains-project/dirty-waters/).\n")
@@ -748,7 +751,15 @@ Gradual reports are enabled by default. You can disable this feature, and get a 
 
 
 def get_s_summary(
-    data, deps_list, project_name, release_version, package_manager, enabled_checks, gradual_report, summary_filename, config={}
+    data,
+    deps_list,
+    project_name,
+    release_version,
+    package_manager,
+    enabled_checks,
+    gradual_report,
+    summary_filename,
+    config={},
 ):
     """
     Get a summary of the static analysis results.


### PR DESCRIPTION
Relates to #166
 
Example of the current state of the report below

---

# Software Supply Chain Report of ericcornelissen/shescape - 3304b1744c0691dbc71f063708023f5d364a7988


## 📚 Table of Contents

- [Enabled Checks](#enabled-checks)
- [Ignore Configuration Summary](#ignore-configuration-summary)
- [Summary of Findings](#summary-of-findings)
- [Fine Grained Information](#fine-grained-information)
- [Call to Action](#call-to-action)
- [Notes](#notes)
- [Glossary](#glossary)
## Enabled Checks

The following checks were requested project-wide:

| Check | Status |
|-------|--------|
| Source Code: `source_code` | ✅ |
| Source Code Sha: `source_code_sha` | ✅ |
| Deprecated: `deprecated` | ❌ |
| Forks: `forks` | ❌ |
| Provenance: `provenance` | ❌ |
| Code Signature: `code_signature` | ✅ |
| Aliased Packages: `aliased_packages` | ❌ |

---

## Ignore Configuration Summary

<details>
<summary>Ignored Checks Per Dependency 🔧</summary>

These dependencies had specific checks excluded based on the configuration file.  
**Note**: If `all` is listed, every check is ignored for that dependency.

| Dependency Pattern | Ignored Checks |
|--------------------|----------------|
| `@types/.+` | `source_code_sha` |
| `concat-map@0.0.1` | `source_code`, `source_code_sha`, `forks` |
| `file-entry-cache@8.0.0` | `source_code`, `source_code_sha`, `forks` |
| `micro-spelling-correcter@1.1.1` | `all` |

</details>

---

## Summary of Findings


<details>
    <summary>How to read the results :book: </summary>
    
 Dirty-waters has analyzed your project dependencies and found different categories for each of them:

    
 - ⚠️⚠️⚠️ : high severity 

    
 - ⚠️⚠️: medium severity 

    
 - ⚠️: low severity 

</details>
        

 ### Total packages in the supply chain: 1071


:heavy_exclamation_mark: Packages with no source code URL (⚠️⚠️⚠️): 5

:no_entry: Packages with repo URL that is 404 (⚠️⚠️⚠️): 1

:wrench: Packages with inaccessible commit SHA/tag (⚠️⚠️): 28

:lock: Packages without code signature (⚠️⚠️): 0

:unlock: Packages with invalid code signature (⚠️⚠️): 0


### Fine grained information

🐬 For further information about software supply chain smells in your project, take a look at the following tables.

<details>
<summary>Source code links that could not be found(6)</summary>
    


|   index | package_name                                                                                 | github_url                              | github_exists   | parent   |
|--------:|:---------------------------------------------------------------------------------------------|:----------------------------------------|:----------------|:---------|
|       1 | [@andrewbranch/untar.js@1.0.3](https://npmjs.com/package/@andrewbranch/untar.js/v/1.0.3)     | No_repo_info_found                      |                 | `[]`     |
|       2 | [@braidai/lang@1.1.1](https://npmjs.com/package/@braidai/lang/v/1.1.1)                       | No_repo_info_found                      |                 | `[]`     |
|       3 | [micro-spelling-correcter@1.1.1](https://npmjs.com/package/micro-spelling-correcter/v/1.1.1) | No_repo_info_found                      |                 | `[]`     |
|       4 | [minipass-pipeline@1.2.4](https://npmjs.com/package/minipass-pipeline/v/1.2.4)               | No_repo_info_found                      |                 | `[]`     |
|       5 | [promise-all-reject-late@1.0.1](https://npmjs.com/package/promise-all-reject-late/v/1.0.1)   | No_repo_info_found                      |                 | `[]`     |
|       6 | [flat-cache@4.0.1](https://npmjs.com/package/flat-cache/v/4.0.1)                             | https://github.com/jaredwray/flat-cache | False           | `[]`     |
</details>

<details>
<summary>List of packages with available source code repos but with inaccessible commit SHAs/tags(28)</summary>
    


| package_name                                                                                           | sha_info                                                                                                                                                   | tag_info                                                                                            | parent                  |
|:-------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------------------|:------------------------|
| [@fast-check/ava@2.0.2](https://npmjs.com/package/@fast-check/ava/v/2.0.2)                             | [Commit SHA not directly available](https://registry.npmjs.com/@fast-check/ava/2.0.2)                                                                      | [Release tag not found in repo](https://api.github.com/repos/dubzzz/fast-check/tags)                | `[]`                    |
| [@jridgewell/gen-mapping@0.3.8](https://npmjs.com/package/@jridgewell/gen-mapping/v/0.3.8)             | [Commit SHA present but not found in repo](https://api.github.com/repos/jridgewell/gen-mapping/commits/0719ff4756b9f1c6c66c244a2ef29e0229e8dcd9)           | [Release tag not found in repo](https://api.github.com/repos/jridgewell/gen-mapping/tags)           | `[]`                    |
| [@loaderkit/resolve@1.0.4](https://npmjs.com/package/@loaderkit/resolve/v/1.0.4)                       | [Commit SHA not directly available](https://registry.npmjs.com/@loaderkit/resolve/1.0.4)                                                                   | [Release tag not found in repo](https://api.github.com/repos/braidnetworks/loaderkit/tags)          | `[]`                    |
| [@pnpm/config.env-replace@1.1.0](https://npmjs.com/package/@pnpm/config.env-replace/v/1.1.0)           | [Commit SHA not directly available](https://registry.npmjs.com/@pnpm/config.env-replace/1.1.0)                                                             | [Release tag not found in repo](https://api.github.com/repos/pnpm/components/tags)                  | `[]`                    |
| [@pnpm/network.ca-file@1.0.2](https://npmjs.com/package/@pnpm/network.ca-file/v/1.0.2)                 | [Commit SHA not directly available](https://registry.npmjs.com/@pnpm/network.ca-file/1.0.2)                                                                | [Release tag not found in repo](https://api.github.com/repos/pnpm/components/tags)                  | `[]`                    |
| [@pnpm/npm-conf@2.3.1](https://npmjs.com/package/@pnpm/npm-conf/v/2.3.1)                               | [Commit SHA not directly available](https://registry.npmjs.com/@pnpm/npm-conf/2.3.1)                                                                       | [Release tag not found in repo](https://api.github.com/repos/pnpm/npm-conf/tags)                    | `[]`                    |
| [@types/debug@4.1.12](https://npmjs.com/package/@types/debug/v/4.1.12)                                 | [Commit SHA not directly available](https://registry.npmjs.com/@types/debug/4.1.12)                                                                        | [Release tag not found in repo](https://api.github.com/repos/DefinitelyTyped/DefinitelyTyped/tags)  | `[]`                    |
| [@types/estree@1.0.7](https://npmjs.com/package/@types/estree/v/1.0.7)                                 | [Commit SHA not directly available](https://registry.npmjs.com/@types/estree/1.0.7)                                                                        | [Release tag not found in repo](https://api.github.com/repos/DefinitelyTyped/DefinitelyTyped/tags)  | `['rollup@4.41.0']`     |
| [@types/http-cache-semantics@4.0.4](https://npmjs.com/package/@types/http-cache-semantics/v/4.0.4)     | [Commit SHA not directly available](https://registry.npmjs.com/@types/http-cache-semantics/4.0.4)                                                          | [Release tag not found in repo](https://api.github.com/repos/DefinitelyTyped/DefinitelyTyped/tags)  | `[]`                    |
| [@types/istanbul-lib-coverage@2.0.6](https://npmjs.com/package/@types/istanbul-lib-coverage/v/2.0.6)   | [Commit SHA not directly available](https://registry.npmjs.com/@types/istanbul-lib-coverage/2.0.6)                                                         | [Release tag not found in repo](https://api.github.com/repos/DefinitelyTyped/DefinitelyTyped/tags)  | `[]`                    |
| [@types/json-schema@7.0.15](https://npmjs.com/package/@types/json-schema/v/7.0.15)                     | [Commit SHA not directly available](https://registry.npmjs.com/@types/json-schema/7.0.15)                                                                  | [Release tag not found in repo](https://api.github.com/repos/DefinitelyTyped/DefinitelyTyped/tags)  | `[]`                    |
| [@types/json5@0.0.29](https://npmjs.com/package/@types/json5/v/0.0.29)                                 | [Commit SHA not directly available](https://registry.npmjs.com/@types/json5/0.0.29)                                                                        | [Release tag not found in repo](https://api.github.com/repos/DefinitelyTyped/DefinitelyTyped/tags)  | `[]`                    |
| [@types/katex@0.16.7](https://npmjs.com/package/@types/katex/v/0.16.7)                                 | [Commit SHA not directly available](https://registry.npmjs.com/@types/katex/0.16.7)                                                                        | [Release tag not found in repo](https://api.github.com/repos/DefinitelyTyped/DefinitelyTyped/tags)  | `[]`                    |
| [@types/mdast@4.0.4](https://npmjs.com/package/@types/mdast/v/4.0.4)                                   | [Commit SHA not directly available](https://registry.npmjs.com/@types/mdast/4.0.4)                                                                         | [Release tag not found in repo](https://api.github.com/repos/DefinitelyTyped/DefinitelyTyped/tags)  | `[]`                    |
| [@types/ms@0.7.34](https://npmjs.com/package/@types/ms/v/0.7.34)                                       | [Commit SHA not directly available](https://registry.npmjs.com/@types/ms/0.7.34)                                                                           | [Release tag not found in repo](https://api.github.com/repos/DefinitelyTyped/DefinitelyTyped/tags)  | `[]`                    |
| [@types/normalize-package-data@2.4.4](https://npmjs.com/package/@types/normalize-package-data/v/2.4.4) | [Commit SHA not directly available](https://registry.npmjs.com/@types/normalize-package-data/2.4.4)                                                        | [Release tag not found in repo](https://api.github.com/repos/DefinitelyTyped/DefinitelyTyped/tags)  | `[]`                    |
| [@types/unist@2.0.11](https://npmjs.com/package/@types/unist/v/2.0.11)                                 | [Commit SHA not directly available](https://registry.npmjs.com/@types/unist/2.0.11)                                                                        | [Release tag not found in repo](https://api.github.com/repos/DefinitelyTyped/DefinitelyTyped/tags)  | `[]`                    |
| [@types/unist@3.0.3](https://npmjs.com/package/@types/unist/v/3.0.3)                                   | [Commit SHA not directly available](https://registry.npmjs.com/@types/unist/3.0.3)                                                                         | [Release tag not found in repo](https://api.github.com/repos/DefinitelyTyped/DefinitelyTyped/tags)  | `[]`                    |
| [acorn-import-attributes@1.9.5](https://npmjs.com/package/acorn-import-attributes/v/1.9.5)             | [Commit SHA not directly available](https://registry.npmjs.com/acorn-import-attributes/1.9.5)                                                              | [Release tag not found in repo](https://api.github.com/repos/xtuc/acorn-import-attributes/tags)     | `[]`                    |
| [cacheable-request@10.2.14](https://npmjs.com/package/cacheable-request/v/10.2.14)                     | [Commit SHA not directly available](https://registry.npmjs.com/cacheable-request/10.2.14)                                                                  | [Release tag not found in repo](https://api.github.com/repos/jaredwray/cacheable/tags)              | `[]`                    |
| [cli-progress@3.12.0](https://npmjs.com/package/cli-progress/v/3.12.0)                                 | [Commit SHA not directly available](https://registry.npmjs.com/cli-progress/3.12.0)                                                                        | [Release tag not found in repo](https://api.github.com/repos/npkgz/cli-progress/tags)               | `[]`                    |
| [keyv@4.5.4](https://npmjs.com/package/keyv/v/4.5.4)                                                   | [Commit SHA not directly available](https://registry.npmjs.com/keyv/4.5.4)                                                                                 | [Release tag not found in repo](https://api.github.com/repos/jaredwray/keyv/tags)                   | `[]`                    |
| [lines-and-columns@1.2.4](https://npmjs.com/package/lines-and-columns/v/1.2.4)                         | [Commit SHA present but not found in repo](https://api.github.com/repos/eventualbuddha/lines-and-columns/commits/3389156275890966091dec7611105fa5d47eb964) | [Release tag not found in repo](https://api.github.com/repos/eventualbuddha/lines-and-columns/tags) | `[]`                    |
| [lodash.get@4.4.2](https://npmjs.com/package/lodash.get/v/4.4.2)                                       | [Commit SHA not directly available](https://registry.npmjs.com/lodash.get/4.4.2)                                                                           | [Release tag not found in repo](https://api.github.com/repos/lodash/lodash/tags)                    | `[]`                    |
| [lodash.merge@4.6.2](https://npmjs.com/package/lodash.merge/v/4.6.2)                                   | [Commit SHA not directly available](https://registry.npmjs.com/lodash.merge/4.6.2)                                                                         | [Release tag not found in repo](https://api.github.com/repos/lodash/lodash/tags)                    | `[]`                    |
| [lodash.truncate@4.4.2](https://npmjs.com/package/lodash.truncate/v/4.4.2)                             | [Commit SHA not directly available](https://registry.npmjs.com/lodash.truncate/4.4.2)                                                                      | [Release tag not found in repo](https://api.github.com/repos/lodash/lodash/tags)                    | `[]`                    |
| [slashes@3.0.12](https://npmjs.com/package/slashes/v/3.0.12)                                           | [Commit SHA not directly available](https://registry.npmjs.com/slashes/3.0.12)                                                                             | [Release tag not found in repo](https://api.github.com/repos/Shakeskeyboarde/slashes/tags)          | `[]`                    |
| [tap-yaml@3.0.0](https://npmjs.com/package/tap-yaml/v/3.0.0)                                           | [Commit SHA present but not found in repo](https://api.github.com/repos/tapjs/tap-yaml/commits/7c022d052fef858727bb58dc37f508a76a6e062b)                   | [Release tag not found in repo](https://api.github.com/repos/tapjs/tap-yaml/tags)                   | `['tap-parser@17.0.0']` |
</details>

All packages have code signature.

All packages have valid code signature.

### Call to Action:

<details>
<summary>👻What do I do now? </summary>


For packages **without source code & accessible SHA/release tags**:

- **Why?** Missing or inaccessible source code makes it impossible to audit the package for security vulnerabilities or malicious code.

1. Pull Request to the maintainer of dependency, requesting correct repository metadata and proper versioning/tagging. 


For packages **without code signature**:

- **Why?** Code signatures help verify the authenticity and integrity of the package, ensuring it hasn't been tampered with.

1. Open an issue in the dependency's repository to request the inclusion of code signature in the CI/CD pipeline. 


For packages **with invalid code signature**:

- **Why?** Invalid signatures could indicate tampering or compromised build processes.

1. It's recommended to verify the code signature and contact the maintainer to fix the issue.
</details>

### Notes

<details>
    <summary>Other info:</summary>
    
- Source code repo is not hosted on GitHub:  3

    This could be due, for example, to the package being hosted on a different platform.

    This does not mean that the source code URL is invalid.

    However, for non-GitHub repositories, not all checks can currently be performed.

|   index | package_name                                                                 | github_url                                             | parent                       |
|--------:|:-----------------------------------------------------------------------------|:-------------------------------------------------------|:-----------------------------|
|       1 | [concat-map@0.0.1](https://npmjs.com/package/concat-map/v/0.0.1)             | Could not find repo from package registry              | `['brace-expansion@1.1.11']` |
|       2 | [file-entry-cache@8.0.0](https://npmjs.com/package/file-entry-cache/v/8.0.0) | Could not find repo from package registry              | `[]`                         |
|       3 | [pp-test-kit@0.5.2](https://npmjs.com/package/pp-test-kit/v/0.5.2)           | git+https://gitlab.com/ericcornelissen/pp-test-kit.git | `[]`                         |
</details>



## Glossary


- `source_code`: Whether a repo URL is present and valid
    - `source_code_sha`: Whether a commit SHA is available and valid
    - `forks`: Whether the repo is a fork
- `deprecated`: Whether the package is marked deprecated
- `provenance`: Whether build provenance/attestation is provided
- `code_signature`: Whether a code signature is present and valid
- `aliased_packages`: Whether a package is aliased under a different name
---

Report created by [dirty-waters](https://github.com/chains-project/dirty-waters/).

Report created on 2025-06-01 18:19:25
- Tool version: 1741634d
- Project Name: ericcornelissen/shescape
- Project Version: 3304b1744c0691dbc71f063708023f5d364a7988
- Package Manager: npm
